### PR TITLE
Fix hot reloading for files not named `game.js`

### DIFF
--- a/lust2d.c
+++ b/lust2d.c
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
     while (!WindowShouldClose()) {
         BeginDrawing();
         if (IsKeyPressed(KEY_F5)) {
-            ret = js_dofile(J, "game.js");
+            ret = js_dofile(J, input_path);
             assert(ret == 0);
         }
         if (js_try(J)) {


### PR DESCRIPTION
Currently, hot reloading is hard-coded to reload `game.js`. If input path is not `game.js`, this will break currently. In this pull request, we change hot reloading to use the CLI input path argument instead of hard-coded `game.js`.